### PR TITLE
fix ruby 3.3 warning

### DIFF
--- a/saxlsx.gemspec
+++ b/saxlsx.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rubyzip', '>= 1.0'
   spec.add_dependency 'ox', '~> 2.1'
+  spec.add_dependency 'bigdecimal'
 
   spec.add_development_dependency 'bundler', ">= 1.5"
   spec.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
warning: bigdecimal was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add bigdecimal to your Gemfile or gemspec.