### PR TITLE
remove to_csv functions

### DIFF
--- a/lib/saxlsx/sheet.rb
+++ b/lib/saxlsx/sheet.rb
@@ -15,14 +15,5 @@ module Saxlsx
       @rows ||= RowsCollection.new(@index, @file_system, @workbook)
     end
 
-    def to_csv(path)
-      FileUtils.mkpath path unless Dir.exists? path
-      File.open("#{path}/#{name}.csv", 'w') do |f|
-        rows.each do |row|
-          f.puts row.map{|c| "\"#{c}\""}.join(',')
-        end
-      end
-    end
-
   end
 end

--- a/lib/saxlsx/workbook.rb
+++ b/lib/saxlsx/workbook.rb
@@ -46,9 +46,5 @@ module Saxlsx
       @base_date ||= date1904 ? DATE_SYSTEM_1904 : DATE_SYSTEM_1900
     end
 
-    def to_csv(path)
-      sheets.each { |s| s.to_csv path }
-    end
-
   end
 end

--- a/spec/sheet_spec.rb
+++ b/spec/sheet_spec.rb
@@ -73,26 +73,6 @@ describe Sheet do
     end
   end
 
-  it 'Export to CSV' do
-    Workbook.open filename do |w|
-      csv_file = "#{tmp_path}/#{w.sheets[0].name}.csv"
-
-      File.should_not be_exists csv_file
-
-      w.sheets[0].to_csv tmp_path
-
-      csv = File.open(csv_file, 'r') { |f| f.readlines }
-      # TODO: newer rubies use lowercase "e" in scientific numbers
-      # csv[0].should eq %{"LevenshteinDistance","3.14","3","2013-12-13T08:00:58+00:00","1970-01-01T00:00:00+00:00","0.34028236692093801E39","2015-02-13T12:40:05+00:00"\n}
-      csv[1].should eq %{"Case sensitive","false","3.0","1970-01-01T01:00:00+00:00"\n}
-      csv[2].should eq "\"Fields\",\"Type\",\"URL Mining\"\n"
-      csv[3].should eq "\"autor\",\"text\",\"false\"\n"
-      csv[4].should eq "\"texto\",\"text\",\"false\"\n"
-      csv[5].should eq "\"url\",\"text\",\"false\"\n"
-      csv[6].should eq "\"comentario\",\"text\",\"false\"\n"
-    end
-  end
-
   it 'Handle missing fonts and dimension tags' do
     filename = "#{File.dirname(__FILE__)}/data/SpecSloppy.xlsx"
 

--- a/spec/workbook_spec.rb
+++ b/spec/workbook_spec.rb
@@ -51,11 +51,4 @@ describe Workbook do
       w.shared_strings.should include 'TST_ModMan_Insulto_SU_Normal'
     end
   end
-
-  it 'Export to CSV' do
-    Workbook.open filename do |w|
-      w.sheets.each { |s| s.should_receive(:to_csv).with(Dir.pwd) }
-      w.to_csv Dir.pwd
-    end
-  end
 end


### PR DESCRIPTION
I suggest removing `to_csv` export function.

It has nothing to do in a XSLX parser.

But this change would break compatibility if somebody were using it.
